### PR TITLE
Unhang npm test with less 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "licenses": [
         {
             "type": "Apache v2",
-            "url": "https://github.com/less/less-plugin-inline-urls/blob/master/LICENSE"
+            "url": "https://github.com/less/less-plugin-advanced-color-functions/blob/master/LICENSE"
         }
     ],
     "main": "lib/index.js",

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,4 @@ lessTester.runTestSet(
     {strictMath: true, silent: true, plugins: [plugin] },
     "functions/");
 
-if (lessTester.finish) {
-	lessTester.finish();
-}
+lessTester.finished();


### PR DESCRIPTION
Call lessTester.finished() to finish the test run. In less.js 2.x this
mistake only omitted the final message "All Passed 1 run" however in
less.js 3.x the test hangs unless .finished() is called.

Also fix a small mistake in package.json